### PR TITLE
Update nuspec for xamarin

### DIFF
--- a/.nuget/Inflatable.Lastfm.nuspec
+++ b/.nuget/Inflatable.Lastfm.nuspec
@@ -17,6 +17,6 @@
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="..\src\IF.Lastfm.Core\bin\Release\IF.Lastfm.Core.dll" target="lib\portable-win8+net45+wp8+wpa81"/>
+		<file src="..\src\IF.Lastfm.Core\bin\Release\IF.Lastfm.Core.dll" target="lib\portable-win8+net45+wp8+wpa81+MonoAndroid+MonoTouch"/>
 	</files>
 </package>


### PR DESCRIPTION
The library already works since is a PCL but we should add mono to the supported platform on the nuspec file