### PR TITLE
fix an ArgumentOutOfRangeException in the Unit Tests causing a few tests to fail.

### DIFF
--- a/src/IF.Lastfm.Core.Tests/Api/Commands/Library/LibraryGetTracksCommandTests.cs
+++ b/src/IF.Lastfm.Core.Tests/Api/Commands/Library/LibraryGetTracksCommandTests.cs
@@ -16,7 +16,7 @@ namespace IF.Lastfm.Core.Tests.Api.Commands.Library
 
         public LibraryGetTracksCommandTests()
         {
-            _command = new GetTracksCommand(MAuth.Object, "rj", "", "", DateTime.MinValue)
+            _command = new GetTracksCommand(MAuth.Object, "rj", "", "", DateTimeOffset.MinValue)
             {
                 Count = 1
             };            


### PR DESCRIPTION
The exception probably occured only with a local time zone with a positive offset, while performing the implicit conversion from DateTime.MinValue to a DateTimeOffset. http://stackoverflow.com/questions/6924198/converting-datetime-minvalue-to-datetimeoffset