### PR TITLE
Added GetSimilarAsyncMbidAsync function

### DIFF
--- a/src/IF.Lastfm.Core/Api/ArtistApi.cs
+++ b/src/IF.Lastfm.Core/Api/ArtistApi.cs
@@ -67,8 +67,21 @@ namespace IF.Lastfm.Core.Api
 
         public async Task<PageResponse<LastArtist>> GetSimilarAsync(string artistname, bool autocorrect = false, int limit = LastFm.DefaultPageLength)
         {
-            var command = new GetSimilarCommand(Auth, artistname)
+            var command = new GetSimilarCommand(Auth)
             {
+                ArtistName = artistname,
+                Autocorrect = autocorrect,
+                Limit = limit,
+                HttpClient = HttpClient
+            };
+            return await command.ExecuteAsync();
+        }
+
+        public async Task<PageResponse<LastArtist>> GetSimilarAsyncMbidAsync(string mbid, bool autocorrect = false, int limit = LastFm.DefaultPageLength)
+        {
+            var command = new GetSimilarCommand(Auth)
+            {
+                ArtistMbid = mbid,
                 Autocorrect = autocorrect,
                 Limit = limit,
                 HttpClient = HttpClient

--- a/src/IF.Lastfm.Core/Api/ArtistApi.cs
+++ b/src/IF.Lastfm.Core/Api/ArtistApi.cs
@@ -77,7 +77,7 @@ namespace IF.Lastfm.Core.Api
             return await command.ExecuteAsync();
         }
 
-        public async Task<PageResponse<LastArtist>> GetSimilarAsyncMbidAsync(string mbid, bool autocorrect = false, int limit = LastFm.DefaultPageLength)
+        public async Task<PageResponse<LastArtist>> GetSimilarByMbidAsync(string mbid, bool autocorrect = false, int limit = LastFm.DefaultPageLength)
         {
             var command = new GetSimilarCommand(Auth)
             {

--- a/src/IF.Lastfm.Core/Api/Commands/Artist/GetSimilarCommand.cs
+++ b/src/IF.Lastfm.Core/Api/Commands/Artist/GetSimilarCommand.cs
@@ -14,19 +14,28 @@ namespace IF.Lastfm.Core.Api.Commands.Artist
     {
         public bool Autocorrect { get; set; }
 
+        public string ArtistMbid { get; set; }
+
         public string ArtistName { get; set; }
 
         public int? Limit { get; set; }
 
-        public GetSimilarCommand(ILastAuth auth, string artistName)
-            : base(auth)
-        {
-            ArtistName = artistName;
-        }
+        public GetSimilarCommand(ILastAuth auth)
+            : base(auth){}
+
 
         public override void SetParameters()
         {
-            Parameters.Add("artist", ArtistName);
+
+            if (ArtistMbid != null)
+            {
+                Parameters.Add("mbid", ArtistMbid);
+            }
+            else
+            {
+                Parameters.Add("artist", ArtistName);
+            }
+
             Parameters.Add("autocorrect", Convert.ToInt32(Autocorrect).ToString());
 
             if (Limit != null)
@@ -37,7 +46,7 @@ namespace IF.Lastfm.Core.Api.Commands.Artist
             DisableCaching();
         }
 
-        public async override Task<PageResponse<LastArtist>> HandleResponse(HttpResponseMessage response)
+        public override async Task<PageResponse<LastArtist>> HandleResponse(HttpResponseMessage response)
         {
             var json = await response.Content.ReadAsStringAsync();
 

--- a/src/IF.Lastfm.Core/Api/IArtistApi.cs
+++ b/src/IF.Lastfm.Core/Api/IArtistApi.cs
@@ -20,7 +20,7 @@ namespace IF.Lastfm.Core.Api
 
         Task<PageResponse<LastArtist>> GetSimilarAsync(string artistname, bool autocorrect = false, int limit = 100);
 
-        Task<PageResponse<LastArtist>> GetSimilarAsyncMbidAsync(string mbid, bool autocorrect = false, int limit = 100);
+        Task<PageResponse<LastArtist>> GetSimilarByMbidAsync(string mbid, bool autocorrect = false, int limit = 100);
 
         Task<PageResponse<LastAlbum>> GetTopAlbumsAsync(string artist,
             bool autocorrect = false,

--- a/src/IF.Lastfm.Core/Api/IArtistApi.cs
+++ b/src/IF.Lastfm.Core/Api/IArtistApi.cs
@@ -20,6 +20,8 @@ namespace IF.Lastfm.Core.Api
 
         Task<PageResponse<LastArtist>> GetSimilarAsync(string artistname, bool autocorrect = false, int limit = 100);
 
+        Task<PageResponse<LastArtist>> GetSimilarAsyncMbidAsync(string mbid, bool autocorrect = false, int limit = 100);
+
         Task<PageResponse<LastAlbum>> GetTopAlbumsAsync(string artist,
             bool autocorrect = false,
             int page = 1,


### PR DESCRIPTION
I did a quick fix as I named the function incorrectly (not inline with similar functions). I had to change the constructor of _GetSimilarCommand _as I noticed other _ByMbidAsync _functions didn't used the constructor but used properties to either set the ArtistName or ArtistMbid.

This breaks backwards compatibility.