### PR TITLE
Add new optional parameters to get recent tracks request

### DIFF
--- a/src/IF.Lastfm.Core.Tests/Api/Commands/UserGetRecentTracksCommandTests.cs
+++ b/src/IF.Lastfm.Core.Tests/Api/Commands/UserGetRecentTracksCommandTests.cs
@@ -3,12 +3,10 @@ using IF.Lastfm.Core.Objects;
 using IF.Lastfm.Core.Tests.Resources;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using IF.Lastfm.Core.Api.Commands.User;
-using Newtonsoft.Json.Linq;
 
 namespace IF.Lastfm.Core.Tests.Api.Commands
 {
@@ -77,7 +75,47 @@ namespace IF.Lastfm.Core.Tests.Api.Commands
             TestHelper.AssertSerialiseEqual(expectedTrack, actual.Single());
         }
 
-        [Test]
+	    [Test]
+	    public async Task HandleExtendedResponse()
+	    {
+		    var command = new GetRecentTracksCommand(MAuth.Object, "rj")
+		    {
+			    Count = 1,
+				Extended = true
+		    };
+
+		    var expectedTrack = new LastTrack
+		    {
+			    ArtistName = "Republika",
+			    ArtistMbid = "116a9ec8-148e-4b3d-8fb9-3d995cc4159e",
+				ArtistUrl = new Uri("https://www.last.fm/music/Republika", UriKind.Absolute),
+				ArtistImages = new LastImageSet(
+					"https://lastfm-img2.akamaized.net/i/u/34s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+					"https://lastfm-img2.akamaized.net/i/u/64s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+					"https://lastfm-img2.akamaized.net/i/u/174s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+					"https://lastfm-img2.akamaized.net/i/u/300x300/e45f11a32d134ed4aeb1ce7b25445fb2.png"),
+				TimePlayed = new DateTime(2018, 06, 27, 16, 32, 16, DateTimeKind.Utc),
+			    Mbid = string.Empty,
+			    Name = "Tak Długo Czekam (Ciało) (live)",
+			    AlbumName = "Koncerty w Trójce - Republika",
+			    Url = new Uri("https://www.last.fm/music/Republika/_/Tak+D%C5%82ugo+Czekam+(Cia%C5%82o)+(live)", UriKind.Absolute),
+			    Images = new LastImageSet(
+					"https://lastfm-img2.akamaized.net/i/u/34s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+					"https://lastfm-img2.akamaized.net/i/u/64s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+					"https://lastfm-img2.akamaized.net/i/u/174s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+				    "https://lastfm-img2.akamaized.net/i/u/300x300/1756f85e7332d469dd17b2e1e0a4d16c.png"),
+				IsLoved = true
+				
+		    };
+
+		    var response = CreateResponseMessage(Encoding.UTF8.GetString(UserApiResponses.UserGetRecentTracksExtended));
+		    var actual = await command.HandleResponse(response);
+
+		    Assert.IsTrue(actual.Success);
+		    TestHelper.AssertSerialiseEqual(expectedTrack, actual.Single());
+	    }
+
+		[Test]
         public async Task HandleErrorResponse()
         {
             var command = new GetRecentTracksCommand(MAuth.Object, "rj")

--- a/src/IF.Lastfm.Core.Tests/IF.Lastfm.Core.Tests.csproj
+++ b/src/IF.Lastfm.Core.Tests/IF.Lastfm.Core.Tests.csproj
@@ -205,6 +205,7 @@
     <None Include="Resources\UserApi\UserGetLovedTracksSingle.json" />
     <None Include="Resources\UserApi\UserGetRecentTracksEmpty.json" />
     <None Include="Resources\UserApi\UserGetRecentTracksError.json" />
+    <None Include="Resources\UserApi\UserGetRecentTracksExtended.json" />
     <None Include="Resources\UserApi\UserGetRecentTracksMissing.json" />
     <None Include="Resources\UserApi\UserGetRecentTracksMultiple.json" />
     <None Include="Resources\UserApi\UserGetRecentTracksSingle.json" />

--- a/src/IF.Lastfm.Core.Tests/Resources/UserApi/UserGetRecentTracksExtended.json
+++ b/src/IF.Lastfm.Core.Tests/Resources/UserApi/UserGetRecentTracksExtended.json
@@ -1,0 +1,60 @@
+﻿{
+  "recenttracks": {
+    "track": {
+      "artist": {
+        "name": "Republika",
+        "mbid": "116a9ec8-148e-4b3d-8fb9-3d995cc4159e",
+        "url": "https://www.last.fm/music/Republika",
+        "image": [
+          {
+            "#text": "https://lastfm-img2.akamaized.net/i/u/34s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+            "size": "small"
+          },
+          {
+            "#text": "https://lastfm-img2.akamaized.net/i/u/64s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+            "size": "medium"
+          },
+          {
+            "#text": "https://lastfm-img2.akamaized.net/i/u/174s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+            "size": "large"
+          },
+          {
+            "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+            "size": "extralarge"
+          }
+        ]
+      },
+      "loved": "1",
+      "name": "Tak Długo Czekam (Ciało) (live)",
+      "streamable": "0",
+      "mbid": "",
+      "album": {
+        "#text": "Koncerty w Trójce - Republika",
+        "mbid": ""
+      },
+      "url": "https://www.last.fm/music/Republika/_/Tak+D%C5%82ugo+Czekam+(Cia%C5%82o)+(live)",
+      "image": [
+        {
+          "#text": "https://lastfm-img2.akamaized.net/i/u/34s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+          "size": "small"
+        },
+        {
+          "#text": "https://lastfm-img2.akamaized.net/i/u/64s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+          "size": "medium"
+        },
+        {
+          "#text": "https://lastfm-img2.akamaized.net/i/u/174s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+          "size": "large"
+        },
+        {
+          "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/1756f85e7332d469dd17b2e1e0a4d16c.png",
+          "size": "extralarge"
+        }
+      ],
+      "date": {
+        "uts": "1530117136",
+        "#text": "27 Jun 2018, 16:32"
+      }
+    }
+  }
+}

--- a/src/IF.Lastfm.Core.Tests/Resources/UserApiResponses.Designer.cs
+++ b/src/IF.Lastfm.Core.Tests/Resources/UserApiResponses.Designer.cs
@@ -113,6 +113,16 @@ namespace IF.Lastfm.Core.Tests.Resources {
         /// <summary>
         ///   Looks up a localized resource of type System.Byte[].
         /// </summary>
+        public static byte[] UserGetRecentTracksExtended {
+            get {
+                object obj = ResourceManager.GetObject("UserGetRecentTracksExtended", resourceCulture);
+                return ((byte[])(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
         public static byte[] UserGetRecentTracksMissing {
             get {
                 object obj = ResourceManager.GetObject("UserGetRecentTracksMissing", resourceCulture);

--- a/src/IF.Lastfm.Core.Tests/Resources/UserApiResponses.resx
+++ b/src/IF.Lastfm.Core.Tests/Resources/UserApiResponses.resx
@@ -133,6 +133,9 @@
   <data name="UserGetRecentTracksError" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>userapi\usergetrecenttrackserror.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
+  <data name="UserGetRecentTracksExtended" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>UserApi\UserGetRecentTracksExtended.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="UserGetRecentTracksMissing" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>userapi\usergetrecenttracksmissing.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>

--- a/src/IF.Lastfm.Core/Api/Commands/LastAsyncCommandBase.cs
+++ b/src/IF.Lastfm.Core/Api/Commands/LastAsyncCommandBase.cs
@@ -50,7 +50,7 @@ This custom attribute must be present on all Commands. For more information, see
 
 	    public int Page
 	    {
-		    get => _page == 0 ? 1 : _page;
+		    get => _page == 0 ? LastFm.DefaultPage : _page;
 		    set
 		    {
 			    if (value < 1) throw new ArgumentOutOfRangeException(nameof(value), "Page property cannot be less than 1");

--- a/src/IF.Lastfm.Core/Api/Commands/LastAsyncCommandBase.cs
+++ b/src/IF.Lastfm.Core/Api/Commands/LastAsyncCommandBase.cs
@@ -46,9 +46,19 @@ This custom attribute must be present on all Commands. For more information, see
     {
         public ILastAuth Auth { get; protected set; }
 
-        public int Page { get; set; }
+	    private int _page;
 
-        public int Count { get; set; }
+	    public int Page
+	    {
+		    get => _page == 0 ? 1 : _page;
+		    set
+		    {
+			    if (value < 1) throw new ArgumentOutOfRangeException(nameof(value), "Page property cannot be less than 1");
+			    _page = value;
+		    }
+	    }
+
+	    public int Count { get; set; }
 
         public Uri Url { get; protected set; }
 

--- a/src/IF.Lastfm.Core/Api/Commands/User/GetRecentTracksCommand.cs
+++ b/src/IF.Lastfm.Core/Api/Commands/User/GetRecentTracksCommand.cs
@@ -16,6 +16,10 @@ namespace IF.Lastfm.Core.Api.Commands.User
 
         public DateTimeOffset? From { get; set; }
 
+	    public DateTimeOffset? To { get; set; }
+
+		public bool Extended { get; set; }
+
         public GetRecentTracksCommand(ILastAuth auth, string username) : base(auth)
         {
             Username = username;
@@ -29,6 +33,11 @@ namespace IF.Lastfm.Core.Api.Commands.User
             {
                 Parameters.Add("from", From.Value.AsUnixTime().ToString());
             }
+
+	        if (To.HasValue)
+	        {
+		        Parameters.Add("to", To.Value.AsUnixTime().ToString());
+			}
 
             AddPagingParameters();
             DisableCaching();

--- a/src/IF.Lastfm.Core/LastFm.cs
+++ b/src/IF.Lastfm.Core/LastFm.cs
@@ -27,7 +27,9 @@ namespace IF.Lastfm.Core
         private const string ResponseFormat = "json";
 
         public const string DefaultLanguageCode = "en";
+
         public const int DefaultPageLength = 20;
+	    public const int DefaultPage = 1;
         
         public static string FormatApiUrl(string method, string apikey, Dictionary<string, string> parameters = null, bool secure = false)
         {

--- a/src/IF.Lastfm.Core/Objects/LastTrack.cs
+++ b/src/IF.Lastfm.Core/Objects/LastTrack.cs
@@ -25,6 +25,10 @@ namespace IF.Lastfm.Core.Objects
 
         public string ArtistMbid { get; set; }
 
+	    public LastImageSet ArtistImages { get; set; }
+
+		public Uri ArtistUrl { get; set; }
+
         public Uri Url { get; set; }
 
         public LastImageSet Images { get; set; }
@@ -85,6 +89,17 @@ namespace IF.Lastfm.Core.Objects
             {
                 t.ArtistName = LastArtist.GetNameFromJToken(artistToken);
                 t.ArtistMbid = artistToken.Value<string>("mbid");
+
+	            if (artistToken.Value<string>("url") != null)
+	            {
+					t.ArtistUrl = new Uri(artistToken.Value<string>("url"), UriKind.Absolute);
+	            }
+
+	            var artistImages = artistToken.SelectToken("image", false);
+	            if (artistImages != null)
+	            {
+					t.ArtistImages = LastImageSet.ParseJToken(artistImages);
+	            }
             }
             else
                 t.ArtistName = artistToken.ToObject<string>();
@@ -123,10 +138,16 @@ namespace IF.Lastfm.Core.Objects
             }
 
             var lovedToken = token.SelectToken("userloved");
-            if (lovedToken != null)
+	        var extendedLovedToken = token.SelectToken("loved");
+			if (lovedToken != null)
             {
                 t.IsLoved = Convert.ToBoolean(lovedToken.Value<int>());
             }
+			else if (extendedLovedToken != null)
+            {
+				t.IsLoved = Convert.ToBoolean(extendedLovedToken.Value<int>());
+			}
+
             var attrToken = token.SelectToken("@attr");
             if (attrToken != null && attrToken.HasValues)
             {


### PR DESCRIPTION
Trying to fix #113 . I have also modified the Page property, so that it defaults to 1 (as in the API's description) and added an unit test to test the extended response parsing.