### PR TITLE
Add optional username parameter to AlbumApi.GetInfo.

### DIFF
--- a/src/IF.Lastfm.Core.Tests.Integration/Commands/AlbumGetInfoTests.cs
+++ b/src/IF.Lastfm.Core.Tests.Integration/Commands/AlbumGetInfoTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace IF.Lastfm.Core.Tests.Integration.Commands
+{
+    public class AlbumGetInfoTests : CommandIntegrationTestsBase
+    {
+        private const string ARTIST_NAME = "The Knife";
+        private const string ALBUM_NAME = "Deep Cuts";
+
+        [Test]
+        public async Task GetInfo_ForUser_Success()
+        {
+            var response = await Lastfm.Album.GetInfoAsync(ARTIST_NAME, ALBUM_NAME, false, INTEGRATION_TEST_USER);
+            var album = response.Content;
+
+            Assert.AreEqual(ARTIST_NAME, album.ArtistName);
+            Assert.Greater(album.UserPlayCount, 0);
+        }
+    }
+}

--- a/src/IF.Lastfm.Core.Tests.Integration/IF.Lastfm.Core.Tests.Integration.csproj
+++ b/src/IF.Lastfm.Core.Tests.Integration/IF.Lastfm.Core.Tests.Integration.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Commands\CommandIntegrationTestsBase.cs" />
     <Compile Include="Commands\TrackScrobbleCommandTests.cs" />
     <Compile Include="Commands\TrackUpdateNowPlayingCommandTests.cs" />
+    <Compile Include="Commands\AlbumGetInfoTests.cs" />
     <Compile Include="Commands\UserGetInfoTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/IF.Lastfm.Core.Tests/Api/Commands/AlbumApi/GetAlbumInfoCommandTests.cs
+++ b/src/IF.Lastfm.Core.Tests/Api/Commands/AlbumApi/GetAlbumInfoCommandTests.cs
@@ -73,6 +73,58 @@ namespace IF.Lastfm.Core.Tests.Api.Commands.AlbumApi
         }
 
         [Test]
+        public async Task HandleSuccessResponseForUser()
+        {
+            _command = new GetInfoCommand(MAuth.Object)
+            {
+                AlbumName = "Ray of Light",
+                ArtistName = "Madonna",
+                UserName = "user"
+            };
+
+            var expectedAlbum = new LastAlbum
+            {
+                ArtistName = "Madonna",
+                ListenerCount = 509271,
+                PlayCount = 7341494,
+                UserPlayCount = 321,
+                Mbid = "ddb3168d-66a9-4b2d-af02-05278da8a23d",
+                Url = new Uri("http://www.last.fm/music/Madonna/Ray+of+Light", UriKind.Absolute),
+                Name = "Ray of Light",
+                ReleaseDateUtc = new DateTime(2005, 09, 13, 0, 0, 0),
+                Id = "1934",
+                Images = new LastImageSet(
+                    "http://userserve-ak.last.fm/serve/34s/37498173.png",
+                    "http://userserve-ak.last.fm/serve/64s/37498173.png",
+                    "http://userserve-ak.last.fm/serve/174s/37498173.png",
+                    "http://userserve-ak.last.fm/serve/300x300/37498173.png",
+                    "http://userserve-ak.last.fm/serve/_/37498173/Ray+of+Light.png"),
+                TopTags = new List<LastTag>
+                {
+                    new LastTag("albums i own", "http://www.last.fm/tag/albums%20i%20own"),
+                    new LastTag("pop", "http://www.last.fm/tag/pop"),
+                    new LastTag("electronic", "http://www.last.fm/tag/electronic"),
+                    new LastTag("dance", "http://www.last.fm/tag/dance"),
+                    new LastTag("madonna", "http://www.last.fm/tag/madonna")
+                }
+            };
+
+            var response = CreateResponseMessage(Encoding.UTF8.GetString(AlbumApiResponses.AlbumGetInfoForUser));
+            var parsed = await _command.HandleResponse(response);
+
+            Assert.IsTrue(parsed.Success);
+
+            var actual = parsed.Content;
+            Assert.IsTrue(actual.Tracks.Count() == 13);
+            actual.Tracks = null;
+
+            var expectedJson = JsonConvert.SerializeObject(expectedAlbum, Formatting.Indented);
+            var actualJson = JsonConvert.SerializeObject(parsed.Content, Formatting.Indented);
+
+            Assert.AreEqual(expectedJson, actualJson, expectedJson.DifferencesTo(actualJson));
+        }
+
+        [Test]
         public async Task HandleErrorResponse()
         {
             var response = CreateResponseMessage(Encoding.UTF8.GetString(AlbumApiResponses.AlbumGetInfoMissing));

--- a/src/IF.Lastfm.Core.Tests/IF.Lastfm.Core.Tests.csproj
+++ b/src/IF.Lastfm.Core.Tests/IF.Lastfm.Core.Tests.csproj
@@ -146,6 +146,7 @@
     <Compile Include="TestHelperTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Resources\AlbumApi\AlbumGetInfoForUser.json" />
     <None Include="Resources\GetTopArtistsError.json" />
     <None Include="Resources\GetTopArtistsSingle.json" />
     <None Include="Resources\GetTopArtistsSuccess.json" />

--- a/src/IF.Lastfm.Core.Tests/Resources/AlbumApi/AlbumGetInfoForUser.json
+++ b/src/IF.Lastfm.Core.Tests/Resources/AlbumApi/AlbumGetInfoForUser.json
@@ -1,0 +1,302 @@
+{
+  "album": {
+    "name": "Ray of Light",
+    "artist": "Madonna",
+    "id": "1934",
+    "mbid": "ddb3168d-66a9-4b2d-af02-05278da8a23d",
+    "url": "http://www.last.fm/music/Madonna/Ray+of+Light",
+    "releasedate": "    13 Sep 2005, 00:00",
+    "image": [
+      {
+        "#text": "http://userserve-ak.last.fm/serve/34s/37498173.png",
+        "size": "small"
+      },
+      {
+        "#text": "http://userserve-ak.last.fm/serve/64s/37498173.png",
+        "size": "medium"
+      },
+      {
+        "#text": "http://userserve-ak.last.fm/serve/174s/37498173.png",
+        "size": "large"
+      },
+      {
+        "#text": "http://userserve-ak.last.fm/serve/300x300/37498173.png",
+        "size": "extralarge"
+      },
+      {
+        "#text": "http://userserve-ak.last.fm/serve/_/37498173/Ray+of+Light.png",
+        "size": "mega"
+      }
+    ],
+    "listeners": "509271",
+    "playcount": "7341494",
+    "userplaycount": "321",
+    "tracks": {
+      "track": [
+        {
+          "name": "Drowned World/Substitute for Love",
+          "duration": "308",
+          "mbid": "",
+          "url": "http://www.last.fm/music/Madonna/_/Drowned+World%2FSubstitute+for+Love",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "1"
+          }
+        },
+        {
+          "name": "Swim",
+          "duration": "300",
+          "mbid": "296cace4-5e5e-40cc-accc-74d9a31e5f8e",
+          "url": "http://www.last.fm/music/Madonna/_/Swim",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "2"
+          }
+        },
+        {
+          "name": "Ray of Light",
+          "duration": "321",
+          "mbid": "20bf8ce2-2e2c-48f4-ba81-4a1b24cf8fae",
+          "url": "http://www.last.fm/music/Madonna/_/Ray+of+Light",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "3"
+          }
+        },
+        {
+          "name": "Candy Perfume Girl",
+          "duration": "276",
+          "mbid": "9d9e6392-50c2-4e44-a560-c23ffd7833da",
+          "url": "http://www.last.fm/music/Madonna/_/Candy+Perfume+Girl",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "4"
+          }
+        },
+        {
+          "name": "Skin",
+          "duration": "381",
+          "mbid": "b42b3682-7964-4e2b-8f51-039656c32c2f",
+          "url": "http://www.last.fm/music/Madonna/_/Skin",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "5"
+          }
+        },
+        {
+          "name": "Nothing Really Matters",
+          "duration": "266",
+          "mbid": "3309c939-3b88-4e92-99b8-46dd1052ec09",
+          "url": "http://www.last.fm/music/Madonna/_/Nothing+Really+Matters",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "6"
+          }
+        },
+        {
+          "name": "Sky Fits Heaven",
+          "duration": "287",
+          "mbid": "2a5437aa-6ad5-4d71-b838-dc0ed928ead4",
+          "url": "http://www.last.fm/music/Madonna/_/Sky+Fits+Heaven",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "7"
+          }
+        },
+        {
+          "name": "Shanti/Ashtangi",
+          "duration": "268",
+          "mbid": "4e354e70-bd0e-461f-b63d-7887ff444edf",
+          "url": "http://www.last.fm/music/Madonna/_/Shanti%2FAshtangi",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "8"
+          }
+        },
+        {
+          "name": "Frozen",
+          "duration": "372",
+          "mbid": "646550f5-8242-4e6d-8ad9-533548a4af41",
+          "url": "http://www.last.fm/music/Madonna/_/Frozen",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "9"
+          }
+        },
+        {
+          "name": "The Power of Good-Bye",
+          "duration": "252",
+          "mbid": "912db777-e783-4856-b5e3-03548355d951",
+          "url": "http://www.last.fm/music/Madonna/_/The+Power+of+Good-Bye",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "10"
+          }
+        },
+        {
+          "name": "To Have and Not to Hold",
+          "duration": "322",
+          "mbid": "bc580d40-0283-47b0-9b7c-2580354f0875",
+          "url": "http://www.last.fm/music/Madonna/_/To+Have+and+Not+to+Hold",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "11"
+          }
+        },
+        {
+          "name": "Little Star",
+          "duration": "318",
+          "mbid": "19be8b9b-f265-448a-b120-939e4a6ba4c3",
+          "url": "http://www.last.fm/music/Madonna/_/Little+Star",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "12"
+          }
+        },
+        {
+          "name": "Mer Girl",
+          "duration": "331",
+          "mbid": "28bf1e1c-5f72-441a-abe7-8e3bef2554b8",
+          "url": "http://www.last.fm/music/Madonna/_/Mer+Girl",
+          "streamable": {
+            "#text": "0",
+            "fulltrack": "0"
+          },
+          "artist": {
+            "name": "Madonna",
+            "mbid": "79239441-bfd5-4981-a70c-55c3f15c1287",
+            "url": "http://www.last.fm/music/Madonna"
+          },
+          "@attr": {
+            "rank": "13"
+          }
+        }
+      ]
+    },
+    "toptags": {
+      "tag": [
+        {
+          "name": "albums i own",
+          "url": "http://www.last.fm/tag/albums%20i%20own"
+        },
+        {
+          "name": "pop",
+          "url": "http://www.last.fm/tag/pop"
+        },
+        {
+          "name": "electronic",
+          "url": "http://www.last.fm/tag/electronic"
+        },
+        {
+          "name": "dance",
+          "url": "http://www.last.fm/tag/dance"
+        },
+        {
+          "name": "madonna",
+          "url": "http://www.last.fm/tag/madonna"
+        }
+      ]
+    },
+    "wiki": {
+      "published": "Sat, 14 Jul 2012 12:33:01 +0000",
+      "summary": "Ray of Light is the seventh studio album by American singer-songwriter Madonna, released on March 3, 1998 by Maverick Records. The album is a pop and dance record, yet, it contains elements of electronic music within its composition, making it a departure from her previous work. Additionally, it incorporates several genres and subgenres, including techno and ambient. The album has several themes, including spirituality.   ",
+      "content": "Ray of Light is the seventh studio album by American singer-songwriter Madonna, released on March 3, 1998 by Maverick Records. The album is a pop and dance record, yet, it contains elements of electronic music within its composition, making it a departure from her previous work. Additionally, it incorporates several genres and subgenres, including techno and ambient. The album has several themes, including spirituality. \n \n After giving birth to her daughter Lourdes, Madonna collaborated with Patrick Leonard and William Orbit in developing the album. After failed sessions with other producers, Madonna pursued a new musical direction with Orbit and incorporated his extensive usage of trance and electronic music in her songs. The recording took place over four months, but experienced problems with the Pro Tools arrangement by Orbit as well as the absence of live bands.\n \n However, upon release, the album was lauded by contemporary critics as a music masterpiece of the decade. Reviewers complimented the album for its mature, restrained nature as well as commending Madonna's musical direction, calling it her &quot;most adventurous&quot; record. In such a way, the album has been included in many critic lists and polls, including Rolling Stone magazine's &quot;The 500 Greatest Albums of All Time&quot;.\n \n Commercially, the album was a success on the world charts, peaking at number one in countries like the United Kingdom, Canada, Australia, New Zealand and mainland Europe. On the U.S. Billboard 200, the album debuted and peaked at number two. The Recording Industry Association of America (RIAA) certified it Quadruple Platinum on March 16, 2000, recognizing four million shipments in the United States, making it her fifth best-selling recording there. Worldwide sales of the album have surpassed 20 million copies.\n \n Five singles were released from the album. The first single &quot;Frozen&quot; was an international success, as was the second one, &quot;Ray of Light&quot;, which won a number of awards for its music video. In 1999, the album received three Grammy Awards, including &quot;Best Pop Vocal Album&quot;, and &quot;Best Dance Recording.&quot; In 2003, the album was ranked #363 on Rolling Stone's 500 Greatest Albums of All Time. Madonna has performed songs from this album on a number of her world tours, most recently the Sticky &amp; Sweet Tour (2008-09).\n        \nUser-contributed text is available under the Creative Commons By-SA License and may also be available under the GNU FDL."
+    }
+  }
+}

--- a/src/IF.Lastfm.Core.Tests/Resources/AlbumApiResponses.Designer.cs
+++ b/src/IF.Lastfm.Core.Tests/Resources/AlbumApiResponses.Designer.cs
@@ -19,7 +19,7 @@ namespace IF.Lastfm.Core.Tests.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class AlbumApiResponses {
@@ -57,6 +57,16 @@ namespace IF.Lastfm.Core.Tests.Resources {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Byte[].
+        /// </summary>
+        public static byte[] AlbumGetInfoForUser {
+            get {
+                object obj = ResourceManager.GetObject("AlbumGetInfoForUser", resourceCulture);
+                return ((byte[])(obj));
             }
         }
         

--- a/src/IF.Lastfm.Core.Tests/Resources/AlbumApiResponses.resx
+++ b/src/IF.Lastfm.Core.Tests/Resources/AlbumApiResponses.resx
@@ -118,6 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="AlbumGetInfoForUser" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>AlbumApi\AlbumGetInfoForUser.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="AlbumGetInfoMissing" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>AlbumApi\AlbumGetInfoMissing.json;System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>

--- a/src/IF.Lastfm.Core/Api/AlbumApi.cs
+++ b/src/IF.Lastfm.Core/Api/AlbumApi.cs
@@ -15,18 +15,19 @@ namespace IF.Lastfm.Core.Api
             Auth = auth;
         }
 
-        public async Task<LastResponse<LastAlbum>> GetInfoAsync(string artistname, string albumname, bool autocorrect = false)
+        public async Task<LastResponse<LastAlbum>> GetInfoAsync(string artistname, string albumname, bool autocorrect = false, string username = null)
         {
             var command = new GetInfoCommand(Auth, albumname, artistname)
                           {
                               Autocorrect = autocorrect,
-                              HttpClient = HttpClient
+                              HttpClient = HttpClient,
+                              UserName = username
                           };
 
             return await command.ExecuteAsync();
         }
 
-        public async Task<LastResponse<LastAlbum>> GetInfoByMbidAsync(string albumMbid, bool autocorrect = false)
+        public async Task<LastResponse<LastAlbum>> GetInfoByMbidAsync(string albumMbid, bool autocorrect = false, string username = null)
         {
             var command = new GetInfoCommand(Auth)
             {

--- a/src/IF.Lastfm.Core/Api/Commands/Album/GetInfoCommand.cs
+++ b/src/IF.Lastfm.Core/Api/Commands/Album/GetInfoCommand.cs
@@ -18,6 +18,8 @@ namespace IF.Lastfm.Core.Api.Commands.Album
 
         public string AlbumName { get; set; }
 
+        public string UserName { get; set; }
+
         public bool Autocorrect { get; set; }
 
         public GetInfoCommand(ILastAuth auth) : base(auth) { }
@@ -39,6 +41,11 @@ namespace IF.Lastfm.Core.Api.Commands.Album
             {
                 Parameters.Add("artist", ArtistName);
                 Parameters.Add("album", AlbumName);
+            }
+
+            if (UserName != null)
+            {
+                Parameters.Add("username", UserName);
             }
 
             Parameters.Add("autocorrect", Convert.ToInt32(Autocorrect).ToString());

--- a/src/IF.Lastfm.Core/Api/IAlbumApi.cs
+++ b/src/IF.Lastfm.Core/Api/IAlbumApi.cs
@@ -8,9 +8,9 @@ namespace IF.Lastfm.Core.Api
     {
         ILastAuth Auth { get; }
 
-        Task<LastResponse<LastAlbum>> GetInfoAsync(string artist, string album, bool autocorrect = false);
+        Task<LastResponse<LastAlbum>> GetInfoAsync(string artist, string album, bool autocorrect = false, string username = null);
 
-        Task<LastResponse<LastAlbum>> GetInfoByMbidAsync(string albumMbid, bool autocorrect = false);
+        Task<LastResponse<LastAlbum>> GetInfoByMbidAsync(string albumMbid, bool autocorrect = false, string username = null);
         
         //Task<PageResponse<BuyLink>> GetBuyLinksForAlbumAsync(string artist,
         //    string album,

--- a/src/IF.Lastfm.Core/Objects/LastAlbum.cs
+++ b/src/IF.Lastfm.Core/Objects/LastAlbum.cs
@@ -21,6 +21,8 @@ namespace IF.Lastfm.Core.Objects
 
         public int? PlayCount { get; set; }
 
+        public int? UserPlayCount { get; set; }
+
         public string Mbid { get; set; }
 
         public IEnumerable<LastTag> TopTags { get; set; }
@@ -85,6 +87,13 @@ namespace IF.Lastfm.Core.Objects
             if (int.TryParse(playCountStr, out playCount))
             {
                 a.PlayCount = playCount;
+            }
+
+            var userPlayCountStr = token.Value<string>("userplaycount");
+            int userPlayCount;
+            if (int.TryParse(userPlayCountStr, out userPlayCount))
+            {
+                a.UserPlayCount = userPlayCount;
             }
 
             var images = token.SelectToken("image");


### PR DESCRIPTION
Resolves #127 - add an optional username parameter to AlbumApi GetInfoAsync and GetInfoByMbidAsync. If provided the result will contain the user play count of that album.