### PR TITLE
Issue 128 - Artist.GetInfoCommand - added lang parameter

### DIFF
--- a/src/IF.Lastfm.Core/Api/Commands/Artist/GetInfoCommand.cs
+++ b/src/IF.Lastfm.Core/Api/Commands/Artist/GetInfoCommand.cs
@@ -35,7 +35,7 @@ namespace IF.Lastfm.Core.Api.Commands.Artist
             {
                 Parameters.Add("artist", ArtistName);
             }
-
+            Parameters.Add("lang", BioLanguage);
             Parameters.Add("autocorrect", Convert.ToInt32(Autocorrect).ToString());
 
             DisableCaching();


### PR DESCRIPTION
Fixed a bug from issue #128. Verified it is working - but did not make any tests because I changed most of the unit tests files in another PR and did not want to make the merge unneccessarily complicated. 