### PR TITLE
Issue 129 - Add artist.get top albums by mbid async

### DIFF
--- a/src/IF.Lastfm.Core.Tests.Integration/Commands/Artist.GetTopAlbumsTests.cs
+++ b/src/IF.Lastfm.Core.Tests.Integration/Commands/Artist.GetTopAlbumsTests.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace IF.Lastfm.Core.Tests.Integration.Commands
+{
+    public class ArtistGetTopAlbumsTests : CommandIntegrationTestsBase
+    {
+        private const string ARTIST_NAME = "The Knife";
+        private const string ARTIST_MBID = "bf710b71-48e5-4e15-9bd6-96debb2e4e98";
+
+        [Test]
+        public async Task ArtistGetTopApbums_ByName_Success()
+        {
+            var response = await Lastfm.Artist.GetTopAlbumsAsync(ARTIST_NAME, false, 1, 10);
+            var albums = response.Content;
+
+            Assert.AreEqual(ARTIST_NAME, albums[0].ArtistName);
+            Assert.AreEqual(10, albums.Count);
+        }
+
+        [Test]
+        public async Task ArtistGetTopApbums_ByMbid_Success()
+        {
+            var response = await Lastfm.Artist.GetTopAlbumsByMbidAsync(ARTIST_MBID);
+            var albums = response.Content;
+
+            Assert.AreEqual(ARTIST_NAME, albums[0].ArtistName);
+            Assert.AreEqual(20, albums.Count);
+        }
+    }
+}

--- a/src/IF.Lastfm.Core.Tests/Api/Commands/Artist/GetTopAlbumsCommandTests.cs
+++ b/src/IF.Lastfm.Core.Tests/Api/Commands/Artist/GetTopAlbumsCommandTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using IF.Lastfm.Core.Api.Commands.Artist;
+using IF.Lastfm.Core.Api.Enums;
+using IF.Lastfm.Core.Objects;
+using IF.Lastfm.Core.Tests.Resources;
+using NUnit.Framework;
+
+namespace IF.Lastfm.Core.Tests.Api.Commands.Artist
+{
+    public class GetTopAlbumsCommandTests : CommandTestsBase
+    {
+        private GetTopAlbumsCommand _commandArtist;
+        private GetTopAlbumsCommand _commandMbid;
+
+        [SetUp]
+        public void Initialise()
+        {
+            _commandArtist = new GetTopAlbumsCommand(MAuth.Object)
+            {
+                ArtistName = "Steely Dan"
+            };
+            _commandMbid = new GetTopAlbumsCommand(MAuth.Object)
+            {
+                ArtistMbid = "e01c3376-15fa-40d7-b747-5f219bdefdd7"
+            };
+        }
+
+        [Test]
+        public async Task GetTopAlbums_HandleResponse_Success()
+        {   
+            _commandArtist.SetParameters();
+            string artistValue;
+            Assert.IsTrue(_commandArtist.Parameters.TryGetValue("artist", out artistValue));
+            Assert.AreEqual("Steely Dan", artistValue);
+
+            var file = GetFileContents("ArtistApi.ArtistGetTopAlbumsSuccess.json");
+            var response = CreateResponseMessage(file);
+            var parsed = await _commandArtist.HandleResponse(response);
+            
+            Assert.IsTrue(parsed.Success, "parsed.success should be true");
+            Assert.AreEqual(10, parsed.Content.Count);
+            Assert.AreEqual(10, parsed.PageSize);
+            Assert.AreEqual(16897, parsed.TotalItems);
+            Assert.AreEqual(1690, parsed.TotalPages);
+            Assert.AreEqual("Steely Dan", parsed.Content[0].ArtistName);
+        }
+
+        [Test]
+        public void GetTopAlbums_ByMbid_Success()
+        {
+            _commandMbid.SetParameters();
+            string mbidValue;
+            Assert.IsTrue(_commandMbid.Parameters.TryGetValue("mbid", out mbidValue));
+            Assert.AreEqual("e01c3376-15fa-40d7-b747-5f219bdefdd7", mbidValue);
+        }
+        
+        [Test]
+        public async Task GetTopAlbums_HandleResponse_Missing()
+        {
+            var file = GetFileContents("ArtistApi.ArtistGetTopAlbumsMissing.json");
+            var response = CreateResponseMessage(file);
+            
+            var parsed = await _commandArtist.HandleResponse(response);
+
+            Assert.IsFalse(parsed.Success, "parsed.success should be false");
+            Assert.AreEqual(LastResponseStatus.MissingParameters, parsed.Status);
+        }
+    }
+}

--- a/src/IF.Lastfm.Core.Tests/Resources/ArtistApi/ArtistGetTopAlbumsMissing.json
+++ b/src/IF.Lastfm.Core.Tests/Resources/ArtistApi/ArtistGetTopAlbumsMissing.json
@@ -1,0 +1,5 @@
+{
+    "error": 6,
+    "message": "The artist you supplied could not be found",
+    "links": []
+}

--- a/src/IF.Lastfm.Core.Tests/Resources/ArtistApi/ArtistGetTopAlbumsSuccess.json
+++ b/src/IF.Lastfm.Core.Tests/Resources/ArtistApi/ArtistGetTopAlbumsSuccess.json
@@ -1,0 +1,303 @@
+{
+    "topalbums": {
+        "album": [
+            {
+                "name": "Can't Buy A Thrill",
+                "playcount": 2897274,
+                "mbid": "3f117e8c-4bb1-3fad-92d8-f931b9102ed1",
+                "url": "https://www.last.fm/music/Steely+Dan/Can%27t+Buy+A+Thrill",
+                "artist": {
+                    "name": "Steely Dan",
+                    "mbid": "e01c3376-15fa-40d7-b747-5f219bdefdd7",
+                    "url": "https://www.last.fm/music/Steely+Dan"
+                },
+                "image": [
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/34s/d2550608de7d41d2c18bcd9f0db1bc00.png",
+                        "size": "small"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/64s/d2550608de7d41d2c18bcd9f0db1bc00.png",
+                        "size": "medium"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/174s/d2550608de7d41d2c18bcd9f0db1bc00.png",
+                        "size": "large"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/d2550608de7d41d2c18bcd9f0db1bc00.png",
+                        "size": "extralarge"
+                    }
+                ]
+            },
+            {
+                "name": "Aja",
+                "playcount": 2419240,
+                "mbid": "cb3d5f81-a4cf-4789-b3bf-724fe75ef1c8",
+                "url": "https://www.last.fm/music/Steely+Dan/Aja",
+                "artist": {
+                    "name": "Steely Dan",
+                    "mbid": "e01c3376-15fa-40d7-b747-5f219bdefdd7",
+                    "url": "https://www.last.fm/music/Steely+Dan"
+                },
+                "image": [
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/34s/5467333ea26fa0d2aef1f49d3b982f04.png",
+                        "size": "small"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/64s/5467333ea26fa0d2aef1f49d3b982f04.png",
+                        "size": "medium"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/174s/5467333ea26fa0d2aef1f49d3b982f04.png",
+                        "size": "large"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/5467333ea26fa0d2aef1f49d3b982f04.png",
+                        "size": "extralarge"
+                    }
+                ]
+            },
+            {
+                "name": "A Decade Of Steely Dan",
+                "playcount": 1108895,
+                "mbid": "7cde51c2-2bbd-47bb-a58b-06d713561880",
+                "url": "https://www.last.fm/music/Steely+Dan/A+Decade+Of+Steely+Dan",
+                "artist": {
+                    "name": "Steely Dan",
+                    "mbid": "e01c3376-15fa-40d7-b747-5f219bdefdd7",
+                    "url": "https://www.last.fm/music/Steely+Dan"
+                },
+                "image": [
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/34s/c6ce2102cff33f954b3e7ef288a7c994.png",
+                        "size": "small"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/64s/c6ce2102cff33f954b3e7ef288a7c994.png",
+                        "size": "medium"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/174s/c6ce2102cff33f954b3e7ef288a7c994.png",
+                        "size": "large"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/c6ce2102cff33f954b3e7ef288a7c994.png",
+                        "size": "extralarge"
+                    }
+                ]
+            },
+            {
+                "name": "Pretzel Logic",
+                "playcount": 1458316,
+                "mbid": "27abd372-c117-4daf-ae69-23210936ecf7",
+                "url": "https://www.last.fm/music/Steely+Dan/Pretzel+Logic",
+                "artist": {
+                    "name": "Steely Dan",
+                    "mbid": "e01c3376-15fa-40d7-b747-5f219bdefdd7",
+                    "url": "https://www.last.fm/music/Steely+Dan"
+                },
+                "image": [
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/34s/b4d29216f43642a2c2e2dfa3d0e36d63.png",
+                        "size": "small"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/64s/b4d29216f43642a2c2e2dfa3d0e36d63.png",
+                        "size": "medium"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/174s/b4d29216f43642a2c2e2dfa3d0e36d63.png",
+                        "size": "large"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/b4d29216f43642a2c2e2dfa3d0e36d63.png",
+                        "size": "extralarge"
+                    }
+                ]
+            },
+            {
+                "name": "The Royal Scam",
+                "playcount": 1009600,
+                "mbid": "586d5dc5-6f65-32d8-bac4-81fdfdef00ab",
+                "url": "https://www.last.fm/music/Steely+Dan/The+Royal+Scam",
+                "artist": {
+                    "name": "Steely Dan",
+                    "mbid": "e01c3376-15fa-40d7-b747-5f219bdefdd7",
+                    "url": "https://www.last.fm/music/Steely+Dan"
+                },
+                "image": [
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/34s/d2e281e662d6c24ccabb75113a77f9e3.png",
+                        "size": "small"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/64s/d2e281e662d6c24ccabb75113a77f9e3.png",
+                        "size": "medium"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/174s/d2e281e662d6c24ccabb75113a77f9e3.png",
+                        "size": "large"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/d2e281e662d6c24ccabb75113a77f9e3.png",
+                        "size": "extralarge"
+                    }
+                ]
+            },
+            {
+                "name": "Countdown To Ecstasy",
+                "playcount": 845082,
+                "mbid": "ad0a3d34-a31b-336c-876b-e780777eff0c",
+                "url": "https://www.last.fm/music/Steely+Dan/Countdown+To+Ecstasy",
+                "artist": {
+                    "name": "Steely Dan",
+                    "mbid": "e01c3376-15fa-40d7-b747-5f219bdefdd7",
+                    "url": "https://www.last.fm/music/Steely+Dan"
+                },
+                "image": [
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/34s/e1c4a381249d4cd3cca813f6c4119e3e.png",
+                        "size": "small"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/64s/e1c4a381249d4cd3cca813f6c4119e3e.png",
+                        "size": "medium"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/174s/e1c4a381249d4cd3cca813f6c4119e3e.png",
+                        "size": "large"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/e1c4a381249d4cd3cca813f6c4119e3e.png",
+                        "size": "extralarge"
+                    }
+                ]
+            },
+            {
+                "name": "Gaucho",
+                "playcount": 928209,
+                "mbid": "cf4bd741-3818-432c-bd62-70a57c965a6d",
+                "url": "https://www.last.fm/music/Steely+Dan/Gaucho",
+                "artist": {
+                    "name": "Steely Dan",
+                    "mbid": "e01c3376-15fa-40d7-b747-5f219bdefdd7",
+                    "url": "https://www.last.fm/music/Steely+Dan"
+                },
+                "image": [
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/34s/145cf0b3fffe44d3c44c2e5ef2d08699.png",
+                        "size": "small"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/64s/145cf0b3fffe44d3c44c2e5ef2d08699.png",
+                        "size": "medium"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/174s/145cf0b3fffe44d3c44c2e5ef2d08699.png",
+                        "size": "large"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/145cf0b3fffe44d3c44c2e5ef2d08699.png",
+                        "size": "extralarge"
+                    }
+                ]
+            },
+            {
+                "name": "Katy Lied",
+                "playcount": 901679,
+                "mbid": "89a9e902-f7a7-459c-a501-2f38c1429223",
+                "url": "https://www.last.fm/music/Steely+Dan/Katy+Lied",
+                "artist": {
+                    "name": "Steely Dan",
+                    "mbid": "e01c3376-15fa-40d7-b747-5f219bdefdd7",
+                    "url": "https://www.last.fm/music/Steely+Dan"
+                },
+                "image": [
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/34s/10f60bc2ff234885c830fe07a94f5457.png",
+                        "size": "small"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/64s/10f60bc2ff234885c830fe07a94f5457.png",
+                        "size": "medium"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/174s/10f60bc2ff234885c830fe07a94f5457.png",
+                        "size": "large"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/10f60bc2ff234885c830fe07a94f5457.png",
+                        "size": "extralarge"
+                    }
+                ]
+            },
+            {
+                "name": "Two Against Nature",
+                "playcount": 517706,
+                "mbid": "43635a52-50de-4873-a7ed-85c0a63b6c72",
+                "url": "https://www.last.fm/music/Steely+Dan/Two+Against+Nature",
+                "artist": {
+                    "name": "Steely Dan",
+                    "mbid": "e01c3376-15fa-40d7-b747-5f219bdefdd7",
+                    "url": "https://www.last.fm/music/Steely+Dan"
+                },
+                "image": [
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/34s/1cc1dee726ff59f428d1080fa8290e12.png",
+                        "size": "small"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/64s/1cc1dee726ff59f428d1080fa8290e12.png",
+                        "size": "medium"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/174s/1cc1dee726ff59f428d1080fa8290e12.png",
+                        "size": "large"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/1cc1dee726ff59f428d1080fa8290e12.png",
+                        "size": "extralarge"
+                    }
+                ]
+            },
+            {
+                "name": "Everything Must Go",
+                "playcount": 391805,
+                "mbid": "b6f5ea90-34f1-4596-a327-a23931f50b39",
+                "url": "https://www.last.fm/music/Steely+Dan/Everything+Must+Go",
+                "artist": {
+                    "name": "Steely Dan",
+                    "mbid": "e01c3376-15fa-40d7-b747-5f219bdefdd7",
+                    "url": "https://www.last.fm/music/Steely+Dan"
+                },
+                "image": [
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/34s/0c1295ae854a4b3b920c14b2d75adeb8.png",
+                        "size": "small"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/64s/0c1295ae854a4b3b920c14b2d75adeb8.png",
+                        "size": "medium"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/174s/0c1295ae854a4b3b920c14b2d75adeb8.png",
+                        "size": "large"
+                    },
+                    {
+                        "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/0c1295ae854a4b3b920c14b2d75adeb8.png",
+                        "size": "extralarge"
+                    }
+                ]
+            }
+        ],
+        "@attr": {
+            "artist": "Steely Dan",
+            "page": "1",
+            "perPage": "10",
+            "totalPages": "1690",
+            "total": "16897"
+        }
+    }
+}

--- a/src/IF.Lastfm.Core/Api/ArtistApi.cs
+++ b/src/IF.Lastfm.Core/Api/ArtistApi.cs
@@ -45,8 +45,21 @@ namespace IF.Lastfm.Core.Api
 
         public async Task<PageResponse<LastAlbum>> GetTopAlbumsAsync(string artist, bool autocorrect = false, int page = 1, int itemsPerPage = LastFm.DefaultPageLength)
         {
-            var command = new GetTopAlbumsCommand(Auth, artist)
+            var command = new GetTopAlbumsCommand(Auth)
             {
+                ArtistName = artist,
+                Page = page,
+                Count = itemsPerPage,
+                HttpClient = HttpClient
+            };
+            return await command.ExecuteAsync();
+        }
+
+        public async Task<PageResponse<LastAlbum>> GetTopAlbumsByMbidAsync(string mbid, bool autocorrect = false, int page = 1, int itemsPerPage = LastFm.DefaultPageLength)
+        {
+            var command = new GetTopAlbumsCommand(Auth)
+            {
+                ArtistMbid = mbid,
                 Page = page,
                 Count = itemsPerPage,
                 HttpClient = HttpClient

--- a/src/IF.Lastfm.Core/Api/Commands/Artist/GetTopAlbumsCommand.cs
+++ b/src/IF.Lastfm.Core/Api/Commands/Artist/GetTopAlbumsCommand.cs
@@ -12,17 +12,21 @@ namespace IF.Lastfm.Core.Api.Commands.Artist
     internal class GetTopAlbumsCommand : GetAsyncCommandBase<PageResponse<LastAlbum>>
     {
         public string ArtistName { get; set; }
+        public string ArtistMbid { get; set; }
 
-        public GetTopAlbumsCommand(ILastAuth auth, string artistname)
-            : base(auth)
-        {
-            ArtistName = artistname;
-        }
+        public GetTopAlbumsCommand(ILastAuth auth )
+            : base(auth)  { }
 
         public override void SetParameters()
         {
-            Parameters.Add("artist", ArtistName);
-
+            if (ArtistMbid != null)
+            {
+                Parameters.Add("mbid", ArtistMbid);
+            }
+            else
+            {
+                Parameters.Add("artist", ArtistName);
+            }
             AddPagingParameters();
             DisableCaching();
         }

--- a/src/IF.Lastfm.Core/Api/IArtistApi.cs
+++ b/src/IF.Lastfm.Core/Api/IArtistApi.cs
@@ -23,6 +23,12 @@ namespace IF.Lastfm.Core.Api
             int page = 1,
             int itemsPerPage = LastFm.DefaultPageLength);
 
+        Task<PageResponse<LastAlbum>> GetTopAlbumsByMbidAsync(string mbid,
+            bool autocorrect = false,
+            int page = 1,
+            int itemsPerPage = LastFm.DefaultPageLength);
+
+
         Task<PageResponse<LastTrack>> GetTopTracksAsync(string artist,
             bool autocorrect = false,
             int page = 1,


### PR DESCRIPTION
As requested in issue #129 - added a new method GetTopAlbumsByMbid in the Artist interface and api. Minor changes to the GetTopAlbums command in order to handle searching by both name and mbid. Added unit tests and an integration test (covering both the existing GetTopAlbums and the new GetTopAlbumsByMbid). Feel free to remove the integration test if you think it is unnecessary. 