### PR TITLE
Add optional parameters to the GetRecentTracks request

### DIFF
--- a/src/IF.Lastfm.Core.Tests.Integration/Commands/TrackScrobbleCommandTests.cs
+++ b/src/IF.Lastfm.Core.Tests.Integration/Commands/TrackScrobbleCommandTests.cs
@@ -45,7 +45,7 @@ namespace IF.Lastfm.Core.Tests.Integration.Commands
             };
             var expectedJson = expectedTrack.TestSerialise();
 
-            var tracks = await Lastfm.User.GetRecentScrobbles(Lastfm.Auth.UserSession.Username, null, 1, 1);
+            var tracks = await Lastfm.User.GetRecentScrobbles(Lastfm.Auth.UserSession.Username, null, null, false, 1, 1);
             var scrobbledTrack = tracks.Single(x => !x.IsNowPlaying.GetValueOrDefault(false));
             
             TestHelper.AssertSerialiseEqual(trackPlayed, scrobbledTrack.TimePlayed);

--- a/src/IF.Lastfm.Core.Tests.Integration/Commands/TrackUpdateNowPlayingCommandTests.cs
+++ b/src/IF.Lastfm.Core.Tests.Integration/Commands/TrackUpdateNowPlayingCommandTests.cs
@@ -30,7 +30,7 @@ namespace IF.Lastfm.Core.Tests.Integration.Commands
 
             await Task.Delay(1000);
 
-            var tracks = await Lastfm.User.GetRecentScrobbles(Lastfm.Auth.UserSession.Username, null, 1, 1);
+            var tracks = await Lastfm.User.GetRecentScrobbles(Lastfm.Auth.UserSession.Username, null, null, false, 1, 1);
 
             var expectedTrack = new LastTrack
             {

--- a/src/IF.Lastfm.Core.Tests/Api/Commands/CommandTestsBase.cs
+++ b/src/IF.Lastfm.Core.Tests/Api/Commands/CommandTestsBase.cs
@@ -34,8 +34,8 @@ namespace IF.Lastfm.Core.Tests.Api.Commands
             {
                 if (stream != null)
                 {
-                    var reader = new StreamReader(stream);
-                    return reader.ReadToEnd();
+                    using (var reader = new StreamReader(stream, Encoding.UTF8))
+                        return reader.ReadToEnd();
                 }
             }
             return string.Empty;

--- a/src/IF.Lastfm.Core.Tests/Api/Commands/Library/LibraryGetTracksCommandTests.cs
+++ b/src/IF.Lastfm.Core.Tests/Api/Commands/Library/LibraryGetTracksCommandTests.cs
@@ -30,6 +30,7 @@ namespace IF.Lastfm.Core.Tests.Api.Commands.Library
                 Name = "Superstition",
                 ArtistMbid = "1ee18fb3-18a6-4c7f-8ba0-bc41cdd0462e",
                 AlbumName = "Number Ones",
+                ArtistUrl = new Uri("http://www.last.fm/music/Stevie+Wonder", UriKind.Absolute),
                 Url = new Uri("http://www.last.fm/music/Stevie+Wonder/_/Superstition", UriKind.Absolute),
                 Images = new LastImageSet(
                     "http://userserve-ak.last.fm/serve/34s/99695819.jpg",
@@ -65,6 +66,7 @@ namespace IF.Lastfm.Core.Tests.Api.Commands.Library
                 Name = "Sultans of Swing",
                 ArtistMbid = "614e3804-7d34-41ba-857f-811bad7c2b7a",
                 AlbumName = "Dire Straits (Remastered)",
+                ArtistUrl = new Uri("http://www.last.fm/music/Dire+Straits", UriKind.Absolute),
                 Url = new Uri("http://www.last.fm/music/Dire+Straits/_/Sultans+of+Swing", UriKind.Absolute),
                 Images = new LastImageSet(
                     "http://userserve-ak.last.fm/serve/34s/56827829.jpg",

--- a/src/IF.Lastfm.Core.Tests/Api/Commands/User/UserGetRecentTracksCommandTests.cs
+++ b/src/IF.Lastfm.Core.Tests/Api/Commands/User/UserGetRecentTracksCommandTests.cs
@@ -1,14 +1,10 @@
 ﻿using IF.Lastfm.Core.Api.Enums;
 using IF.Lastfm.Core.Objects;
-using IF.Lastfm.Core.Tests.Resources;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using IF.Lastfm.Core.Api.Commands.User;
-using Newtonsoft.Json.Linq;
 
 namespace IF.Lastfm.Core.Tests.Api.Commands
 {
@@ -75,6 +71,48 @@ namespace IF.Lastfm.Core.Tests.Api.Commands
             var file = GetFileContents("UserApi.UserGetRecentTracksSingle.json");
             var response = CreateResponseMessage(file);
             //var response = CreateResponseMessage(Encoding.UTF8.GetString(UserApiResponses.UserGetRecentTracksSingle));
+            var actual = await command.HandleResponse(response);
+
+            Assert.IsTrue(actual.Success);
+            TestHelper.AssertSerialiseEqual(expectedTrack, actual.Single());
+        }
+
+        [Test]
+        public async Task HandleExtendedResponse()
+        {
+            var command = new GetRecentTracksCommand(MAuth.Object, "rj")
+            {
+                Count = 1,
+                Extended = true
+            };
+
+            var expectedTrack = new LastTrack
+            {
+                ArtistName = "Republika",
+                ArtistMbid = "116a9ec8-148e-4b3d-8fb9-3d995cc4159e",
+                ArtistUrl = new Uri("https://www.last.fm/music/Republika", UriKind.Absolute),
+                ArtistImages = new LastImageSet(
+                    "https://lastfm-img2.akamaized.net/i/u/34s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+                    "https://lastfm-img2.akamaized.net/i/u/64s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+                    "https://lastfm-img2.akamaized.net/i/u/174s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+                    "https://lastfm-img2.akamaized.net/i/u/300x300/e45f11a32d134ed4aeb1ce7b25445fb2.png"),
+                TimePlayed = new DateTime(2018, 06, 27, 16, 32, 16, DateTimeKind.Utc),
+                Mbid = string.Empty,
+                Name = "Tak Długo Czekam (Ciało) (live)",
+                AlbumName = "Koncerty w Trójce - Republika",
+                Url = new Uri("https://www.last.fm/music/Republika/_/Tak+D%C5%82ugo+Czekam+(Cia%C5%82o)+(live)", UriKind.Absolute),
+                Images = new LastImageSet(
+                    "https://lastfm-img2.akamaized.net/i/u/34s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+                    "https://lastfm-img2.akamaized.net/i/u/64s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+                    "https://lastfm-img2.akamaized.net/i/u/174s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+                    "https://lastfm-img2.akamaized.net/i/u/300x300/1756f85e7332d469dd17b2e1e0a4d16c.png"),
+                IsLoved = true
+
+            };
+
+            var file = GetFileContents("UserApi.UserGetRecentTracksExtended.json");
+            var response = CreateResponseMessage(file);
+
             var actual = await command.HandleResponse(response);
 
             Assert.IsTrue(actual.Success);

--- a/src/IF.Lastfm.Core.Tests/Resources/UserApi/UserGetRecentTracksExtended.json
+++ b/src/IF.Lastfm.Core.Tests/Resources/UserApi/UserGetRecentTracksExtended.json
@@ -1,0 +1,60 @@
+{
+  "recenttracks": {
+    "track": {
+      "artist": {
+        "name": "Republika",
+        "mbid": "116a9ec8-148e-4b3d-8fb9-3d995cc4159e",
+        "url": "https://www.last.fm/music/Republika",
+        "image": [
+          {
+            "#text": "https://lastfm-img2.akamaized.net/i/u/34s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+            "size": "small"
+          },
+          {
+            "#text": "https://lastfm-img2.akamaized.net/i/u/64s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+            "size": "medium"
+          },
+          {
+            "#text": "https://lastfm-img2.akamaized.net/i/u/174s/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+            "size": "large"
+          },
+          {
+            "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/e45f11a32d134ed4aeb1ce7b25445fb2.png",
+            "size": "extralarge"
+          }
+        ]
+      },
+      "loved": "1",
+      "name": "Tak D³ugo Czekam (Cia³o) (live)",
+      "streamable": "0",
+      "mbid": "",
+      "album": {
+        "#text": "Koncerty w Trójce - Republika",
+        "mbid": ""
+      },
+      "url": "https://www.last.fm/music/Republika/_/Tak+D%C5%82ugo+Czekam+(Cia%C5%82o)+(live)",
+      "image": [
+        {
+          "#text": "https://lastfm-img2.akamaized.net/i/u/34s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+          "size": "small"
+        },
+        {
+          "#text": "https://lastfm-img2.akamaized.net/i/u/64s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+          "size": "medium"
+        },
+        {
+          "#text": "https://lastfm-img2.akamaized.net/i/u/174s/1756f85e7332d469dd17b2e1e0a4d16c.png",
+          "size": "large"
+        },
+        {
+          "#text": "https://lastfm-img2.akamaized.net/i/u/300x300/1756f85e7332d469dd17b2e1e0a4d16c.png",
+          "size": "extralarge"
+        }
+      ],
+      "date": {
+        "uts": "1530117136",
+        "#text": "27 Jun 2018, 16:32"
+      }
+    }
+  }
+}

--- a/src/IF.Lastfm.Core/Api/Commands/LastAsyncCommandBase.cs
+++ b/src/IF.Lastfm.Core/Api/Commands/LastAsyncCommandBase.cs
@@ -46,7 +46,17 @@ This custom attribute must be present on all Commands. For more information, see
     {
         public ILastAuth Auth { get; protected set; }
 
-        public int Page { get; set; }
+        private int _page;
+
+        public int Page
+        {
+            get => _page == 0 ? LastFm.DefaultPage : _page;
+            set
+            {
+                if (value < 1) throw new ArgumentOutOfRangeException(nameof(value), "Page property cannot be less than 1");
+                _page = value;
+            }
+        }
 
         public int Count { get; set; }
 

--- a/src/IF.Lastfm.Core/Api/Commands/User/GetRecentTracksCommand.cs
+++ b/src/IF.Lastfm.Core/Api/Commands/User/GetRecentTracksCommand.cs
@@ -16,6 +16,10 @@ namespace IF.Lastfm.Core.Api.Commands.User
 
         public DateTimeOffset? From { get; set; }
 
+        public DateTimeOffset? To { get; set; }
+
+        public bool Extended { get; set; }
+
         public GetRecentTracksCommand(ILastAuth auth, string username) : base(auth)
         {
             Username = username;
@@ -28,6 +32,11 @@ namespace IF.Lastfm.Core.Api.Commands.User
             if (From.HasValue)
             {
                 Parameters.Add("from", From.Value.AsUnixTime().ToString());
+            }
+
+            if (To.HasValue)
+            {
+                Parameters.Add("to", To.Value.AsUnixTime().ToString());
             }
 
             AddPagingParameters();

--- a/src/IF.Lastfm.Core/Api/IUserApi.cs
+++ b/src/IF.Lastfm.Core/Api/IUserApi.cs
@@ -24,7 +24,9 @@ namespace IF.Lastfm.Core.Api
             int pagenumber = 0,
             int count = LastFm.DefaultPageLength);
 
-        Task<PageResponse<LastTrack>> GetRecentScrobbles(string username, DateTimeOffset? since = null, int pagenumber = 0, int count = LastFm.DefaultPageLength);
+        Task<PageResponse<LastTrack>> GetRecentScrobbles(string username, DateTimeOffset? from = null, 
+            DateTimeOffset? to = null, bool extendedResponse = false, int pagenumber = LastFm.DefaultPage,
+            int count = LastFm.DefaultPageLength);
 
         Task<PageResponse<LastStation>> GetRecentStations(string username,
             int pagenumber,

--- a/src/IF.Lastfm.Core/Api/UserApi.cs
+++ b/src/IF.Lastfm.Core/Api/UserApi.cs
@@ -58,17 +58,24 @@ namespace IF.Lastfm.Core.Api
         /// Gets a list of recent scrobbled tracks for this user in reverse date order.
         /// </summary>
         /// <param name="username">Username to get scrobbles for.</param>
-        /// <param name="since">Lower threshold for scrobbles. Will not return scrobbles from before this time.</param>
+        /// <param name="from">Lower threshold for scrobbles. Will not return scrobbles from before this time.</param>
+        /// <param name="to">Upper threshold for scrobbles. Will not return scrobbles from after this time.</param>
         /// <param name="pagenumber">Page numbering starts from 1. If set to 0, will not include the "now playing" track</param>
+        /// <param name="extendedResponse">Determines if the response will contain extended data in each artist 
+        /// and whether or not the user has loved each track</param>
         /// <param name="count">Amount of scrobbles to return for this page.</param>
         /// <returns>Enumerable of LastTrack</returns>
-        public async Task<PageResponse<LastTrack>> GetRecentScrobbles(string username, DateTimeOffset? since = null, int pagenumber = 1, int count = LastFm.DefaultPageLength)
+        public async Task<PageResponse<LastTrack>> GetRecentScrobbles(string username, DateTimeOffset? from = null, 
+            DateTimeOffset? to = null, bool extendedResponse = false, int pagenumber = LastFm.DefaultPage,
+            int count = LastFm.DefaultPageLength)
         {
             var command = new GetRecentTracksCommand(Auth, username)
             {
                 Page = pagenumber,
                 Count = count,
-                From = since,
+                From = from,
+                To = to,
+                Extended = extendedResponse,
                 HttpClient = HttpClient
             };
 

--- a/src/IF.Lastfm.Core/LastFm.cs
+++ b/src/IF.Lastfm.Core/LastFm.cs
@@ -27,8 +27,10 @@ namespace IF.Lastfm.Core
         private const string ResponseFormat = "json";
 
         public const string DefaultLanguageCode = "en";
+
         public const int DefaultPageLength = 20;
-        
+        public const int DefaultPage = 1;
+
         public static string FormatApiUrl(string method, string apikey, Dictionary<string, string> parameters = null, bool secure = false)
         {
             if (parameters == null)

--- a/src/IF.Lastfm.Core/Objects/LastTrack.cs
+++ b/src/IF.Lastfm.Core/Objects/LastTrack.cs
@@ -25,6 +25,10 @@ namespace IF.Lastfm.Core.Objects
 
         public string ArtistMbid { get; set; }
 
+        public LastImageSet ArtistImages { get; set; }
+
+        public Uri ArtistUrl { get; set; }
+
         public Uri Url { get; set; }
 
         public LastImageSet Images { get; set; }
@@ -85,6 +89,17 @@ namespace IF.Lastfm.Core.Objects
             {
                 t.ArtistName = LastArtist.GetNameFromJToken(artistToken);
                 t.ArtistMbid = artistToken.Value<string>("mbid");
+
+                if (artistToken.Value<string>("url") != null)
+                {
+                    t.ArtistUrl = new Uri(artistToken.Value<string>("url"), UriKind.Absolute);
+                }
+
+                var artistImages = artistToken.SelectToken("image", false);
+                if (artistImages != null)
+                {
+                    t.ArtistImages = LastImageSet.ParseJToken(artistImages);
+                }
             }
             else
                 t.ArtistName = artistToken.ToObject<string>();
@@ -123,10 +138,16 @@ namespace IF.Lastfm.Core.Objects
             }
 
             var lovedToken = token.SelectToken("userloved");
+            var extendedLovedToken = token.SelectToken("loved");
             if (lovedToken != null)
             {
                 t.IsLoved = Convert.ToBoolean(lovedToken.Value<int>());
             }
+            else if (extendedLovedToken != null)
+            {
+                t.IsLoved = Convert.ToBoolean(extendedLovedToken.Value<int>());
+            }
+
             var attrToken = token.SelectToken("@attr");
             if (attrToken != null && attrToken.HasValues)
             {


### PR DESCRIPTION
Contiunation of #123 
Fixing #113. For now one unit test fails because of some response encoding issues - I'll try to fix that later today. 