### PR TITLE
Fixed GetTop commands from the Tag Api

### DIFF
--- a/src/IF.Lastfm.Core.Tests/Resources/Tag/GetTopAlbumsSingle.json
+++ b/src/IF.Lastfm.Core.Tests/Resources/Tag/GetTopAlbumsSingle.json
@@ -1,5 +1,5 @@
 {
-  "topalbums": {
+  "albums": {
     "album": {
       "name": "Number Ones",
       "mbid": "12cc16cb-5649-4e1a-bd10-a8a496280990",

--- a/src/IF.Lastfm.Core.Tests/Resources/Tag/GetTopAlbumsSuccess.json
+++ b/src/IF.Lastfm.Core.Tests/Resources/Tag/GetTopAlbumsSuccess.json
@@ -1,5 +1,5 @@
 {
-  "topalbums": {
+  "albums": {
     "album": [
       {
         "name": "Number Ones",

--- a/src/IF.Lastfm.Core/Api/Commands/Tag/GetTopAlbumsCommand.cs
+++ b/src/IF.Lastfm.Core/Api/Commands/Tag/GetTopAlbumsCommand.cs
@@ -33,7 +33,7 @@ namespace IF.Lastfm.Core.Api.Commands.Tag
             if (LastFm.IsResponseValid(json, out status) && response.IsSuccessStatusCode)
             {
                 var jtoken = JsonConvert.DeserializeObject<JToken>(json);
-                var resultsToken = jtoken.SelectToken("topalbums");
+                var resultsToken = jtoken.SelectToken("albums");
                 var itemsToken = resultsToken.SelectToken("album");
 
                 return PageResponse<LastAlbum>.CreateSuccessResponse(itemsToken, resultsToken, LastAlbum.ParseJToken, LastPageResultsType.Attr);

--- a/src/IF.Lastfm.Core/Api/Commands/Tag/GetTopTracksCommand.cs
+++ b/src/IF.Lastfm.Core/Api/Commands/Tag/GetTopTracksCommand.cs
@@ -33,7 +33,7 @@ namespace IF.Lastfm.Core.Api.Commands.Tag
             if (LastFm.IsResponseValid(json, out status) && response.IsSuccessStatusCode)
             {
                 var jtoken = JsonConvert.DeserializeObject<JToken>(json);
-                var resultsToken = jtoken.SelectToken("toptracks");
+                var resultsToken = jtoken.SelectToken("tracks");
                 var itemsToken = resultsToken.SelectToken("track");
 
                 return PageResponse<LastTrack>.CreateSuccessResponse(itemsToken, resultsToken, LastTrack.ParseJToken, LastPageResultsType.Attr);

--- a/src/IF.Lastfm.Core/Objects/LastTag.cs
+++ b/src/IF.Lastfm.Core/Objects/LastTag.cs
@@ -35,6 +35,12 @@ namespace IF.Lastfm.Core.Objects
             Count = count;
         }
 
+        public LastTag(string name, int? count = null)
+        {
+            Name = name;
+            Count = count;
+        }
+
         internal static LastTag ParseJToken(JToken token)
         {
             return ParseJToken(token, null);
@@ -43,7 +49,11 @@ namespace IF.Lastfm.Core.Objects
         internal static LastTag ParseJToken(JToken token, string relatedTag)
         {
             var name = token.Value<string>("name");
-            var url = token.Value<string>("url");
+
+            Uri uri = null;
+            var urlToken = token.Value<string>("url");
+            if (!String.IsNullOrWhiteSpace(urlToken))
+               uri = new Uri(urlToken, UriKind.RelativeOrAbsolute);
 
             int? count = null;
             var countToken = token.SelectToken("count") ?? token.SelectToken("taggings");
@@ -66,8 +76,9 @@ namespace IF.Lastfm.Core.Objects
                 reach = reachToken.ToObject<int?>();
             }
 
-            return new LastTag(name, url, count)
+            return new LastTag(name, count)
             {
+                Url = uri,
                 Streamable = streamable,
                 RelatedTo = relatedTag,
                 Reach = reach


### PR DESCRIPTION
Lastfm's documentation is off for these endpoints:

- tag.getTopAlbums
- tag.getTopTags

Documentation says that it should return a "topalbums" and "toptracks" object respectively but it's actually returning "albums" and "tracks".

This is related to issue #172 and this PR fixes that.

There was another bug in the **tag.getTopTags** command.
For this endpoint Lastfm doesn't return an URL object and this was throwig a NullReferenceException in the LastTag constructor. I added an overloaded constructor to fix the problem.